### PR TITLE
docs: add astro website

### DIFF
--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -1,0 +1,5 @@
+import { defineConfig } from 'astro/config';
+
+export default defineConfig({
+	srcDir: './src',
+});

--- a/website/package.json
+++ b/website/package.json
@@ -1,0 +1,14 @@
+{
+	"name": "crumbjs-website",
+	"version": "0.0.1",
+	"private": true,
+	"type": "module",
+	"scripts": {
+		"dev": "astro dev",
+		"build": "astro build",
+		"preview": "astro preview"
+	},
+	"dependencies": {
+		"astro": "^4.14.1"
+	}
+}

--- a/website/src/layouts/BaseLayout.astro
+++ b/website/src/layouts/BaseLayout.astro
@@ -1,0 +1,38 @@
+---
+const { title } = Astro.props;
+---
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width" />
+    <title>{title ? `${title} - CrumbJS` : 'CrumbJS'}</title>
+    <style>
+      :root { --orange: #f97316; --orange-light: #fdba74; }
+      body { font-family: system-ui, sans-serif; margin: 0; line-height: 1.6; background: #fff7ed; color: #1f2937; }
+      header { background: var(--orange); color: white; padding: 0.5rem 1rem; display: flex; align-items: center; flex-wrap: wrap; }
+      nav a { color: white; margin-right: 1rem; text-decoration: none; font-weight: 600; }
+      nav a:hover { text-decoration: underline; }
+      main { max-width: 960px; margin: auto; padding: 2rem; }
+      pre { background: #1f2937; color: #f8fafc; padding: 1rem; border-radius: 0.5rem; overflow-x: auto; }
+      code { background: #f1f5f9; padding: 0.2rem 0.4rem; border-radius: 0.25rem; }
+      footer { text-align: center; padding: 2rem 0; color: #4b5563; }
+    </style>
+  </head>
+  <body>
+    <header>
+      <nav>
+        <a href="/">Overview</a>
+        <a href="/quick-start">Quick Start</a>
+        <a href="/routing">Routing</a>
+        <a href="/middleware">Middleware</a>
+        <a href="/lifecycle">Life Cycle</a>
+        <a href="/plugins">Plugins</a>
+      </nav>
+    </header>
+    <main>
+      <slot />
+    </main>
+    <footer>© {new Date().getFullYear()} CrumbJS</footer>
+  </body>
+</html>

--- a/website/src/pages/index.md
+++ b/website/src/pages/index.md
@@ -1,0 +1,16 @@
+---
+layout: ../layouts/BaseLayout.astro
+title: Overview
+---
+
+# CrumbJS
+
+CrumbJS is a lightweight API framework built for [Bun](https://bun.com/) that adds schema validation and automatic documentation on top of Bun's router while keeping an Express-like developer experience.
+
+## Goals
+
+- Focus on Bun's runtime
+- First-class TypeScript support
+- Simple, minimal core
+
+CrumbJS pairs well with Bun's speed and uses Zod for validation with zero lock‑in.

--- a/website/src/pages/lifecycle.md
+++ b/website/src/pages/lifecycle.md
@@ -1,0 +1,37 @@
+---
+layout: ../layouts/BaseLayout.astro
+title: Life Cycle
+---
+
+# Life Cycle
+
+Each request is processed by the `Processor`, which builds the context and runs middlewares before executing your handler.
+
+## Context helpers
+
+- `body`, `query`, `params` – validated data
+- `setStatus(code, text?)` – set response status
+- `setHeader(key, value)` – add response header
+- `getResponseHeaders()` – read final headers
+- `bearer()` and `basicCredentials()` – parse auth headers
+- `set()` and `get()` – per-request storage
+
+```ts
+import { App, spec } from '@crumbjs/core';
+import { z } from 'zod';
+
+const app = new App();
+
+app.post(
+	'/posts',
+	({ body, setStatus }) => {
+		setStatus(201);
+		return { id: 1, ...body };
+	},
+	{
+		body: z.object({ title: z.string() }),
+	},
+);
+
+app.serve();
+```

--- a/website/src/pages/middleware/cors.md
+++ b/website/src/pages/middleware/cors.md
@@ -1,0 +1,21 @@
+---
+layout: ../../layouts/BaseLayout.astro
+title: CORS Middleware
+---
+
+# CORS
+
+Allow or restrict cross‑origin requests.
+
+```ts
+import { App } from '@crumbjs/core';
+import { cors } from '@crumbjs/core/middlewares/cors';
+
+const app = new App();
+
+app.use(cors({ origin: 'https://example.com' }));
+
+app.get('/data', () => ({ ok: true }));
+
+app.serve();
+```

--- a/website/src/pages/middleware/index.md
+++ b/website/src/pages/middleware/index.md
@@ -1,0 +1,36 @@
+---
+layout: ../../layouts/BaseLayout.astro
+title: Middleware
+---
+
+# Middleware
+
+Middlewares run before your handlers. Register global middleware with `app.use()` or pass them per-route in the route config.
+
+```ts
+import { App } from '@crumbjs/core';
+
+const app = new App();
+
+const logger = async (ctx, next) => {
+	console.log(ctx.request.method, ctx.url.pathname);
+	return next();
+};
+
+app.use(logger); // global
+
+const auth = async (ctx, next) => {
+	if (!ctx.headers.authorization) return new Response('Unauthorized', { status: 401 });
+	return next();
+};
+
+app.get('/secret', { use: auth }, () => '🔒');
+
+app.serve();
+```
+
+Included middlewares:
+
+- [CORS](./cors)
+- [Secure headers](./secure-headers)
+- [Signals](./signals)

--- a/website/src/pages/middleware/secure-headers.md
+++ b/website/src/pages/middleware/secure-headers.md
@@ -1,0 +1,21 @@
+---
+layout: ../../layouts/BaseLayout.astro
+title: Secure Headers
+---
+
+# Secure Headers
+
+Sets common security‑related headers like `Content-Security-Policy` or `X-Frame-Options`.
+
+```ts
+import { App } from '@crumbjs/core';
+import { secureHeaders } from '@crumbjs/core/middlewares/secure-headers';
+
+const app = new App();
+
+app.use(secureHeaders());
+
+app.get('/', () => 'ok');
+
+app.serve();
+```

--- a/website/src/pages/middleware/signals.md
+++ b/website/src/pages/middleware/signals.md
@@ -1,0 +1,21 @@
+---
+layout: ../../layouts/BaseLayout.astro
+title: Signals
+---
+
+# Signals
+
+Log request metrics like method, path, status and duration.
+
+```ts
+import { App } from '@crumbjs/core';
+import { signals } from '@crumbjs/core/middlewares/signals';
+
+const app = new App();
+
+app.use(signals()); // or signals(true) to always log
+
+app.get('/', () => 'pong');
+
+app.serve();
+```

--- a/website/src/pages/plugins.md
+++ b/website/src/pages/plugins.md
@@ -1,0 +1,23 @@
+---
+layout: ../layouts/BaseLayout.astro
+title: Plugins
+---
+
+# Plugins
+
+CrumbJS supports an extensible plugin system. Currently available:
+
+## BullMQ
+
+Job queue backed by Redis using BullMQ.
+
+```ts
+import { App } from '@crumbjs/core';
+import { bullmqPlugin } from '@crumbjs/bullmq';
+
+const app = new App();
+app.use(bullmqPlugin());
+app.serve();
+```
+
+See the `bullmq` folder for source and usage details.

--- a/website/src/pages/quick-start.md
+++ b/website/src/pages/quick-start.md
@@ -1,0 +1,34 @@
+---
+layout: ../layouts/BaseLayout.astro
+title: Quick Start
+---
+
+# Quick Start
+
+## Create a new project
+
+```bash
+bun create crumbjs my-app
+cd my-app
+bun install
+```
+
+## Add core to an existing project
+
+```bash
+bun add @crumbjs/core
+```
+
+## Minimal server
+
+```ts
+import { App } from '@crumbjs/core';
+
+const app = new App();
+
+app.get('/hello', () => ({ hello: 'world' }));
+
+app.serve();
+```
+
+Run with `bun run src/index.ts`.

--- a/website/src/pages/routing.md
+++ b/website/src/pages/routing.md
@@ -1,0 +1,29 @@
+---
+layout: ../layouts/BaseLayout.astro
+title: Routing
+---
+
+# Routing
+
+Define routes with the HTTP verbs you need. Each handler receives a typed context with params, body, query and helpers.
+
+```ts
+import { App } from '@crumbjs/core';
+
+const app = new App();
+
+app.get('/users', () => []);
+app.post('/users', ({ body }) => body);
+app.put('/users/:id', ({ params, body }) => ({ id: params.id, ...body }));
+app.patch('/users/:id', ({ params, body }) => ({ id: params.id, ...body }));
+app.delete('/users/:id', ({ params }) => ({ id: params.id }));
+app.options('/users', () => new Response(null, { headers: { Allow: 'GET,POST' } }));
+app.head('/users', () => new Response(null));
+
+app.static('/assets', './public'); // serve a directory
+app.staticFile('/favicon.ico', './public/favicon.ico'); // serve a single file
+app.proxy('/search/*', 'https://example.com'); // proxy matching routes
+app.proxyAll('/api/*', 'https://backend.internal'); // proxy preserving path
+
+app.serve();
+```


### PR DESCRIPTION
## Summary
- add Astro documentation site with orange theme and navigation
- document routing, middleware, lifecycle and BullMQ plugin
- remove logo images to avoid binary files and adjust layout

## Testing
- `npm run format:check`
- `npm --prefix website install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/astro)*
- `npm --prefix website run build` *(fails: astro: not found)*

------
https://chatgpt.com/codex/tasks/task_e_689d4525ba44832aa642d4cc108bd161